### PR TITLE
Update "All Jobs" permalink

### DIFF
--- a/templates/comeet-position-page.php
+++ b/templates/comeet-position-page.php
@@ -1,7 +1,6 @@
 <?php if ($show_all_link) : ?>
-	<?php $post = get_post(get_the_ID()); ?>
 	<div class="all-jobs-link">
-		<a href="<?php echo site_url() . '/' . $post->post_name; ?>">&larr; All Jobs</a>
+		<a href="<?php echo get_permalink( get_the_ID() ) ?>">&larr; All Jobs</a>
 	</div>
 <?php endif; ?>
 <?php include 'comeet-position-page-common.php' ?>

--- a/templates/comeet-sub-page.php
+++ b/templates/comeet-sub-page.php
@@ -4,7 +4,7 @@
     $options = $this->get_options();
     $post = get_post($options['post_id']);
     ?>
-    <a href="<?php echo site_url() . '/' . $post->post_name; ?>">&larr; All Jobs</a>
+    <a href="<?php echo get_permalink( $post ) ?>">&larr; All Jobs</a>
 </div>
 <?php endif; ?>
 


### PR DESCRIPTION
I've updated the way we're building the "All Jobs" permalink in two of the template files:
- `comeet-sub-page.php`
- `comeet-position-page.php`

Previously the "All Jobs" permalink was being built via `<?php echo site_url() . '/' . $post->post_name; ?>`. By appending the `post_name` to the `site_url`, we are just adding the page's slug. This means we're generating the wrong URL for sub-pages. 

Here's an example: Let's say we have `https://example.com/about-us/careers`. The previous method would yield only `https://example.com/careers` as the href for "All Jobs" in these templates. But, we need `https://example.com/about-us/careers`. To get that full URL, we must use `get_permalink()` which is the preferred "WordPress way" for retrieving a page's URL.